### PR TITLE
Support ipv6.

### DIFF
--- a/lib/geokit.rb
+++ b/lib/geokit.rb
@@ -22,6 +22,7 @@ end
 
 path = File.expand_path(File.dirname(__FILE__))
 $:.unshift path unless $:.include?(path)
+require 'geokit/utils'
 require 'geokit/core_ext'
 require 'geokit/geocoders'
 require 'geokit/mappable'

--- a/lib/geokit/geocoders/base_ip.rb
+++ b/lib/geokit/geocoders/base_ip.rb
@@ -27,7 +27,7 @@ module Geokit
       end
 
       def self.ip?(ip)
-        /^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})?$/.match(ip)
+        Geokit::Utils.ip?(ip)
       end
 
       def self.process(format, ip)

--- a/lib/geokit/multi_geocoder.rb
+++ b/lib/geokit/multi_geocoder.rb
@@ -71,7 +71,7 @@ module Geokit
         if args.last.is_a?(Hash) && args.last.key?(:provider_order)
           args.last.delete(:provider_order)
         else
-          if address.is_a?(String) && /^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/.match(address)
+          if address.is_a?(String) && Geokit::Utils.ip?(address)
             Geokit::Geocoders.ip_provider_order
           else
             Geokit::Geocoders.provider_order

--- a/lib/geokit/utils.rb
+++ b/lib/geokit/utils.rb
@@ -1,0 +1,9 @@
+require 'resolv'
+
+module Geokit
+  class Utils
+    def self.ip?(value)
+      Regexp.union([Resolv::IPv4::Regex, Resolv::IPv6::Regex]).match?(value)
+    end
+  end
+end


### PR DESCRIPTION
The existing ip regexes only supported ipv4. This uses the ipv4 and ipv6 regexes from the "resolv" library in the standard library to detect both types of ip addresses. It comes with all of the limitations of those ip regexes.

Upstream maintainers don't seem too active since this hasn't been merged in a while https://github.com/geokit/geokit/pull/253. I'll contribute this upstream though once we start running it in production and see what happens.